### PR TITLE
fix: 修复选择应用无法禁用和隐藏

### DIFF
--- a/packages/spaas-app/.spaas/views/main-layout/components/app-options/index.vue
+++ b/packages/spaas-app/.spaas/views/main-layout/components/app-options/index.vue
@@ -23,8 +23,8 @@
 <script>
 import routeInfo from '@/const/route-info';
 
-const NONE = '2';
-const DISABLED = '3';
+const NONE = '0'; // 1: 显示；0：隐藏
+const DISABLED = false; // true: 启用；false: 禁用
 
 export default {
   name: 'app-options',
@@ -64,7 +64,7 @@ export default {
     },
     isDisabled() {
       const curInfo = routeInfo[this.matchedPath];
-      return curInfo && curInfo.appType === DISABLED;
+      return curInfo && curInfo.enable === DISABLED;
     },
     hasHide() {
       const curInfo = routeInfo[this.matchedPath];


### PR DESCRIPTION
- 为什么修改？
 1.子模块无法禁用和隐藏

- 导致BUG原因？
 经检查发现是主模块.spaas里边值未对应，故提出PR

   遵循以下图片逻辑
![image](https://user-images.githubusercontent.com/20368037/75231938-4e437500-57f1-11ea-9f2b-03e82029054c.png)

- 主模块测试用例
 1.隐藏选择应用用例
![image](https://user-images.githubusercontent.com/20368037/75232102-95ca0100-57f1-11ea-857b-ca083f6cca2c.png)
 2.禁用选择应用用例
![image2](https://s2.ax1x.com/2020/02/25/3Ybb0U.png)
