### PR TITLE
fix: 修复模块化后改造子应用不显示VueTools

### DIFF
--- a/packages/spaas-app/.spaas/plugins/element.js
+++ b/packages/spaas-app/.spaas/plugins/element.js
@@ -89,3 +89,6 @@ Vue.prototype.$alert = MessageBox.alert;
 Vue.prototype.$confirm = MessageBox.confirm;
 Vue.prototype.$prompt = MessageBox.prompt;
 Vue.prototype.$message = Message;
+
+// 显示Vue-tools
+Vue.config.devtools = process.env && process.env.NODE_ENV !== 'production' ? true : false;

--- a/packages/spaas-app/.spaas/views/main-layout/components/app-options/index.vue
+++ b/packages/spaas-app/.spaas/views/main-layout/components/app-options/index.vue
@@ -23,8 +23,8 @@
 <script>
 import routeInfo from '@/const/route-info';
 
-const NONE = '2';
-const DISABLED = '3';
+const NONE = '0'; // 1: 显示；0：隐藏
+const DISABLED = false; // true: 启用；false: 禁用
 
 export default {
   name: 'app-options',
@@ -64,7 +64,7 @@ export default {
     },
     isDisabled() {
       const curInfo = routeInfo[this.matchedPath];
-      return curInfo && curInfo.appType === DISABLED;
+      return curInfo && curInfo.enable === DISABLED;
     },
     hasHide() {
       const curInfo = routeInfo[this.matchedPath];


### PR DESCRIPTION
- 为什么?

模块化改造后，子应用无法显示VueTools

- 测试用例
![image](https://user-images.githubusercontent.com/20368037/75236586-f577da80-57f8-11ea-8631-1dc879e03e91.png)



