### PR TITLE
fix: 修复拷贝svg文件后无法读取bug

### DIFF
--- a/packages/spaas-app/.spaas/icons/index.js
+++ b/packages/spaas-app/.spaas/icons/index.js
@@ -4,6 +4,8 @@ import SvgIcon from '@/components/SvgIcon'; // svg component
 // register globally
 Vue.component('svg-icon', SvgIcon);
 
-const req = require.context('./svg', false, /\.svg$/);
+//包含了父级文件夹（包含子目录）下面
+const req = require.context('../', true, /\.svg$/);
+
 const requireAll = requireContext => requireContext.keys().map(requireContext);
 requireAll(req);

--- a/packages/spaas-app/.spaas/plugins/element.js
+++ b/packages/spaas-app/.spaas/plugins/element.js
@@ -89,3 +89,6 @@ Vue.prototype.$alert = MessageBox.alert;
 Vue.prototype.$confirm = MessageBox.confirm;
 Vue.prototype.$prompt = MessageBox.prompt;
 Vue.prototype.$message = Message;
+
+// 显示Vue-tools
+Vue.config.devtools = process.env && process.env.NODE_ENV !== 'production' ? true : false;

--- a/packages/spaas-app/.spaas/views/main-layout/components/app-options/index.vue
+++ b/packages/spaas-app/.spaas/views/main-layout/components/app-options/index.vue
@@ -23,8 +23,8 @@
 <script>
 import routeInfo from '@/const/route-info';
 
-const NONE = '0'; // 1: 显示；0：隐藏
-const DISABLED = false; // true: 启用；false: 禁用
+const NONE = '2';
+const DISABLED = '3';
 
 export default {
   name: 'app-options',
@@ -64,7 +64,7 @@ export default {
     },
     isDisabled() {
       const curInfo = routeInfo[this.matchedPath];
-      return curInfo && curInfo.enable === DISABLED;
+      return curInfo && curInfo.appType === DISABLED;
     },
     hasHide() {
       const curInfo = routeInfo[this.matchedPath];

--- a/packages/spaas-app/.spaas/views/main-layout/components/app-options/index.vue
+++ b/packages/spaas-app/.spaas/views/main-layout/components/app-options/index.vue
@@ -23,8 +23,8 @@
 <script>
 import routeInfo from '@/const/route-info';
 
-const NONE = '2';
-const DISABLED = '3';
+const NONE = '0'; // 1: 显示；0：隐藏
+const DISABLED = false; // true: 启用；false: 禁用
 
 export default {
   name: 'app-options',
@@ -64,7 +64,7 @@ export default {
     },
     isDisabled() {
       const curInfo = routeInfo[this.matchedPath];
-      return curInfo && curInfo.appType === DISABLED;
+      return curInfo && curInfo.enable === DISABLED;
     },
     hasHide() {
       const curInfo = routeInfo[this.matchedPath];


### PR DESCRIPTION
- why？
因cli文件读取后，无法识别icons/svg里边子目录，故svg无法渲染

- 解决方法:
![image](https://user-images.githubusercontent.com/20368037/75311002-5acada80-5890-11ea-9633-28872aff40f1.png)

- 测试用例
![image](https://user-images.githubusercontent.com/20368037/75311079-a8474780-5890-11ea-83d1-80a68ebc9c9a.png)
